### PR TITLE
PWAインストールボタン機能を追加

### DIFF
--- a/apps/next/app/page.module.css
+++ b/apps/next/app/page.module.css
@@ -61,6 +61,13 @@
   gap: 16px;
 }
 
+.buttons {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  justify-content: center;
+}
+
 .ctas a {
   appearance: none;
   border-radius: 128px;
@@ -109,6 +116,27 @@ button.secondary {
   background: transparent;
   border-color: var(--gray-alpha-200);
   min-width: 180px;
+}
+
+button.primary {
+  appearance: none;
+  border-radius: 128px;
+  height: 48px;
+  padding: 0 20px;
+  border: none;
+  font-family: var(--font-geist-sans);
+  border: 1px solid transparent;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 500;
+  background: var(--foreground);
+  color: var(--background);
+  gap: 8px;
 }
 
 .footer {
@@ -161,6 +189,10 @@ button.secondary {
   }
 
   .ctas {
+    flex-direction: column;
+  }
+
+  .buttons {
     flex-direction: column;
   }
 

--- a/apps/next/app/page.tsx
+++ b/apps/next/app/page.tsx
@@ -1,5 +1,5 @@
 import Image, { type ImageProps } from "next/image";
-import { Button } from "@repo/ui/button";
+import { Button, PWAInstallButton } from "@repo/ui";
 import styles from "./page.module.css";
 
 type Props = Omit<ImageProps, "src"> & {
@@ -63,9 +63,16 @@ export default function Home() {
             Read our docs
           </a>
         </div>
-        <Button appName="web" className={styles.secondary}>
-          Open alert
-        </Button>
+        <div className={styles.buttons}>
+          <Button appName="Next.js" className={styles.secondary}>
+            Open alert
+          </Button>
+          <PWAInstallButton 
+            className={styles.primary}
+            installText="📱 アプリをインストール"
+            promptText="Next.js PWAアプリをホーム画面に追加"
+          />
+        </div>
       </main>
       <footer className={styles.footer}>
         <a

--- a/apps/vite/src/App.css
+++ b/apps/vite/src/App.css
@@ -40,3 +40,29 @@
 .read-the-docs {
   color: #888;
 }
+
+.pwa-install-btn {
+  margin-top: 1rem;
+  background: #646cff;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color 0.25s;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.pwa-install-btn:hover {
+  background: #535bf2;
+}
+
+.pwa-install-btn:focus,
+.pwa-install-btn:focus-visible {
+  outline: 4px auto -webkit-focus-ring-color;
+}

--- a/apps/vite/src/App.tsx
+++ b/apps/vite/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
+import { PWAInstallButton } from '@repo/ui'
 import './App.css'
 
 function App() {
@@ -24,6 +25,11 @@ function App() {
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
+        <PWAInstallButton 
+          installText="📱 アプリをインストール"
+          promptText="Vite PWAアプリをホーム画面に追加"
+          className="pwa-install-btn"
+        />
       </div>
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,6 @@
+export { Button } from "./button";
+export { Card } from "./card";
+export { Code } from "./code";
+export { PWAInstallButton } from "./pwa-install-button";
+export { usePWAInstall, checkPWAInstalled } from "./use-pwa-install";
+export type { PWAInstallState } from "./use-pwa-install";

--- a/packages/ui/src/pwa-install-button.tsx
+++ b/packages/ui/src/pwa-install-button.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { usePWAInstall } from "./use-pwa-install";
+
+interface PWAInstallButtonProps {
+  className?: string;
+  installText?: string;
+  promptText?: string;
+}
+
+export const PWAInstallButton = ({
+  className = "",
+  installText = "アプリをインストール",
+  promptText = "PWAをインストールしますか？"
+}: PWAInstallButtonProps) => {
+  const { isInstalled, isInstallable, install } = usePWAInstall();
+
+  // インストール済みまたはインストール不可の場合は表示しない
+  if (isInstalled || !isInstallable) {
+    return null;
+  }
+
+  const defaultClassName = `
+    inline-flex items-center justify-center
+    px-4 py-2 
+    bg-blue-600 hover:bg-blue-700 
+    text-white font-medium rounded-lg
+    transition-colors duration-200
+    focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
+    disabled:opacity-50 disabled:cursor-not-allowed
+  `.replace(/\s+/g, ' ').trim();
+
+  return (
+    <button
+      onClick={install}
+      className={className || defaultClassName}
+      aria-label={promptText}
+      title={promptText}
+    >
+      <svg 
+        className="w-4 h-4 mr-2" 
+        fill="none" 
+        stroke="currentColor" 
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path 
+          strokeLinecap="round" 
+          strokeLinejoin="round" 
+          strokeWidth={2} 
+          d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" 
+        />
+      </svg>
+      {installText}
+    </button>
+  );
+};

--- a/packages/ui/src/use-pwa-install.tsx
+++ b/packages/ui/src/use-pwa-install.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+export interface PWAInstallState {
+  isInstalled: boolean;
+  isInstallable: boolean;
+  deferredPrompt: BeforeInstallPromptEvent | null;
+  install: () => Promise<void>;
+}
+
+export const checkPWAInstalled = (): boolean => {
+  // スタンドアロンモードでの実行チェック
+  if (typeof window !== 'undefined' && window.matchMedia('(display-mode: standalone)').matches) {
+    return true;
+  }
+  
+  // iOS Safari PWA チェック
+  if (typeof window !== 'undefined' && (window.navigator as any).standalone === true) {
+    return true;
+  }
+  
+  return false;
+};
+
+export const usePWAInstall = (): PWAInstallState => {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isInstalled, setIsInstalled] = useState(false);
+  const [isInstallable, setIsInstallable] = useState(false);
+
+  useEffect(() => {
+    // 初期チェック
+    setIsInstalled(checkPWAInstalled());
+
+    // beforeinstallprompt イベントリスナー
+    const handleBeforeInstallPrompt = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setIsInstallable(true);
+    };
+
+    // appinstalled イベントリスナー
+    const handleAppInstalled = () => {
+      setIsInstalled(true);
+      setIsInstallable(false);
+      setDeferredPrompt(null);
+    };
+
+    // display-mode の変更を監視
+    const mediaQuery = window.matchMedia('(display-mode: standalone)');
+    const handleDisplayModeChange = () => {
+      setIsInstalled(checkPWAInstalled());
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    window.addEventListener('appinstalled', handleAppInstalled);
+    mediaQuery.addEventListener('change', handleDisplayModeChange);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', handleAppInstalled);
+      mediaQuery.removeEventListener('change', handleDisplayModeChange);
+    };
+  }, []);
+
+  const install = async (): Promise<void> => {
+    if (!deferredPrompt) {
+      // iOS Safari などのフォールバック
+      if (typeof navigator !== 'undefined' && /iPhone|iPad|iPod|Mac/.test(navigator.userAgent)) {
+        alert('このアプリをインストールするには:\n1. 共有ボタン をタップ\n2. "ホーム画面に追加" を選択');
+        return;
+      }
+      
+      alert('このブラウザではPWAインストールがサポートされていません。');
+      return;
+    }
+
+    try {
+      await deferredPrompt.prompt();
+      const choiceResult = await deferredPrompt.userChoice;
+      
+      if (choiceResult.outcome === 'accepted') {
+        console.log('PWAインストールが承認されました');
+      } else {
+        console.log('PWAインストールが拒否されました');
+      }
+      
+      setDeferredPrompt(null);
+      setIsInstallable(false);
+    } catch (error) {
+      console.error('PWAインストールエラー:', error);
+    }
+  };
+
+  return {
+    isInstalled,
+    isInstallable,
+    deferredPrompt,
+    install
+  };
+};


### PR DESCRIPTION
## 主な変更点
- PWAインストール状態を管理するカスタムフック (`usePWAInstall`) を追加
- PWAインストールボタンコンポーネントを共有UIライブラリに追加
- Next.jsアプリとViteアプリ両方にPWAインストールボタンを実装

## 機能
- PWAインストール可能性の自動検知
- インストール済み状態の自動管理
- iOS Safari等でのフォールバック対応
- Next.js/Vite両対応の再利用可能コンポーネント

🤖 Generated with [Claude Code](https://claude.ai/code)